### PR TITLE
Fix issue18

### DIFF
--- a/src/split.rs
+++ b/src/split.rs
@@ -256,7 +256,14 @@ impl<'a> Runner<'a> {
         // this will allow our current branch to be fast-forwardable
         // onto upstream (well really its going to be the exact same branch)
         if num_commits_to_take == 0 {
-            let last_commit_arg = format!("{}~1", current_branch);
+            // if current branch only has one commit, dont use the <branch>~1
+            // git rebase syntax. it will cause git rebase to fail
+            let rebase_last_one = if num_commits_of_current > 1 {
+                "~1"
+            } else {
+                ""
+            };
+            let last_commit_arg = format!("{}{}", current_branch, rebase_last_one);
             let args = [
                 "git", "rebase", "--onto",
                 upstream_branch.as_str(),

--- a/src/split.rs
+++ b/src/split.rs
@@ -251,8 +251,35 @@ impl<'a> Runner<'a> {
             println!("{}no commit of {} exists in {}. rebasing non-interactively", self.log_p, current_branch, upstream_branch);
         }
 
-        // either of the above special cases will do the same thing: rebase non-interactively
-        if num_commits_to_take == num_commits_of_current || num_commits_to_take == 0 {
+        // if there's nothing to topbase, then we want to just
+        // rebase the last commit onto the upstream branch.
+        // this will allow our current branch to be fast-forwardable
+        // onto upstream (well really its going to be the exact same branch)
+        if num_commits_to_take == 0 {
+            let last_commit_arg = format!("{}~1", current_branch);
+            let args = [
+                "git", "rebase", "--onto",
+                upstream_branch.as_str(),
+                last_commit_arg.as_str(),
+                current_branch.as_str()
+            ];
+
+            if self.dry_run {
+                let arg_str = args.join(" ");
+                println!("{}", arg_str);
+                return self;
+            }
+
+            match exec_helpers::execute(&args) {
+                Err(e) => panic!("Failed to rebase: {}", e),
+                Ok(_) => (),
+            };
+            return self;
+        }
+
+        // if we need to topbase the entirety of the current branch
+        // it will be better to do a regular rebase
+        if num_commits_to_take == num_commits_of_current {
             if self.dry_run {
                 println!("git rebase {}", upstream_branch);
                 return self;

--- a/test/splitin/end-to-end.bats
+++ b/test/splitin/end-to-end.bats
@@ -369,11 +369,16 @@ function teardown() {
 @test 'if topbase finds 0, it shouldnt rebase interactively' {
     curr_dir="$PWD"
     cd "$BATS_TMPDIR/test_remote_repo2"
+    # for this test, we want to ensure that the remote repo has 2 commits
+    # in its history after the rewrite:
+    echo "doesntmatter" > file1.txt
+    git add file1.txt && git commit -m "doesntmatter"
+    # now this commit matters because it should have the same blob as the local repository will
     echo "file1" > file1.txt
     git add file1.txt && git commit -m "file1"
 
     # simulate the remote repo and the local repo being
-    # up to date with each other
+    # up to date with each other (same blob as above)
     cd "$curr_dir"
     echo "file1" > file1.txt
     git add file1.txt && git commit -m "file1_local"

--- a/test/splitin/end-to-end.bats
+++ b/test/splitin/end-to-end.bats
@@ -403,6 +403,38 @@ function teardown() {
     [[ $git_log_now == $git_log_before ]]
 }
 
+@test 'if topbase finds 0 (AND remote only has one commit), it shouldnt rebase interactively' {
+    curr_dir="$PWD"
+    cd "$BATS_TMPDIR/test_remote_repo2"
+    echo "file1" > file1.txt
+    git add file1.txt && git commit -m "file1"
+
+    # simulate the remote repo and the local repo being
+    # up to date with each other (same blob as above)
+    cd "$curr_dir"
+    echo "file1" > file1.txt
+    git add file1.txt && git commit -m "file1_local"
+
+    echo "on master local:"
+    echo "$(git log --oneline)"
+
+    repo_file_contents="
+    remote_repo=\"..$SEP$test_remote_repo2\"
+    include=\"file1.txt\"
+    "
+    echo "$repo_file_contents" > repo_file.sh
+    git_log_before="$(git log --oneline)"
+    run $PROGRAM_PATH split-in repo_file.sh -t --verbose
+    echo "$output"
+    echo "$(git log --oneline)"
+    git_log_now="$(git log --oneline)"
+    [[ $status == "0" ]]
+    [[ $output == *"rebasing non-interactively"* ]]
+    # it should still rebase because that will make the output
+    # branch fast-forwardable
+    [[ $git_log_now == $git_log_before ]]
+}
+
 @test 'if topbase finds the entire history, it shouldnt rebase interactively' {
     curr_dir="$PWD"
     cd "$BATS_TMPDIR/test_remote_repo2"


### PR DESCRIPTION
closes #18 

if a topbase detects that the most recent of current exists in upstream, then it should just rebase the current top commit, rather than the entire rewritten branch. the entire rebase could (and most often will) result in conflicts.

Since the user is running `--topbase`, it is assumed they dont care about any of the history, they just want the recent updates, and they want it to be fast-forwardable, so this behavior is probably fine.
