### PR TITLE
Fix nested include as

### DIFF
--- a/src/split_in.rs
+++ b/src/split_in.rs
@@ -297,8 +297,16 @@ pub fn gen_include_as_arg_files_from_folder(
         // with the provided dest prefix, so strip the current prefix here
         let f_str = f.strip_prefix(&src).unwrap().to_str().unwrap();
 
+        // the replace here will prevent properly including
+        // any files that have a backslash in them. I think
+        // it would be too difficult to support such files for now.
+        // also this replacement will still work on windows because
+        // git-filter-repo actually expects the paths to have
+        // unix-like path separators
         let new_src = format!("{}{}", src_str, f_str);
+        let new_src = new_src.replace("\\", "/");
         let new_dest = format!("{}{}", dest, f_str);
+        let new_dest = new_dest.replace("\\", "/");
         // we only want to add unique paths, so
         // if we already added this one, dont add it again
         if unique_files.contains(&new_src) {

--- a/src/split_in.rs
+++ b/src/split_in.rs
@@ -270,7 +270,6 @@ pub fn gen_include_as_arg_files_from_folder(
     valid_files: &Vec<PathBuf>,
     unique_files: &mut HashSet<String>,
 ) -> String {
-    println!("VALID FILES: {:?}", valid_files);
     let mut file_vec = vec![];
     // ignore any file that isn't in the list of valid files
     let should_ignore = |p: &PathBuf| {
@@ -470,8 +469,8 @@ mod test {
 
         let expected1 = "--path-rename test/general/end-to-end.bats:sometestlib/end-to-end.bats";
         let expected2 = "--path-rename test/general/usage.bats:sometestlib/usage.bats";
-        let expected = format!("{} {}", expected1, expected2);
-        assert_eq!(s, expected);
+        assert!(s.contains(expected1));
+        assert!(s.contains(expected2));
     }
 
     // this test requires reading files/folders from the root of the

--- a/test/splitin/end-to-end.bats
+++ b/test/splitin/end-to-end.bats
@@ -200,6 +200,53 @@ function teardown() {
     [[ ! -f rootfile1.txt ]]
 }
 
+@test 'properly handles nested folder renames/moves' {
+    # save current dir to cd back to later
+    curr_dir="$PWD"
+    # setup the test remote repo:
+    cd "$BATS_TMPDIR/test_remote_repo2"
+    mkdir -p lib
+    echo "rootfile1.txt" > rootfile1.txt
+    echo "libfile1.txt" > lib/libfile1.txt
+    echo "libfile2.txt" > lib/libfile2.txt
+    echo "srcfile1.txt" > srcfile1.txt
+    echo "srcfile2.txt" > lib/srcfile2.txt
+    git add .
+    git commit -m "adds files"
+    echo "repo2 dir:"
+    echo "$(find . -type f -not -path '*/\.*')"
+    cd "$curr_dir"
+
+    repo_file_contents="
+    repo_name=\"doesnt_matter\"
+    remote_repo=\"..$SEP$test_remote_repo2\"
+    include_as=(
+        \"lib/src/srcfile1.txt\" \"srcfile1.txt\"
+        \"lib/src/\" \"lib/\"
+        \"lib/\" \" \"
+    )
+    "
+
+    echo "$repo_file_contents" > repo_file.sh
+    echo "$(git split in repo_file.sh --dry-run)"
+
+    run $PROGRAM_PATH split-in repo_file.sh --verbose
+    echo "$output"
+    echo "local repo dir after split:"
+    echo "$(find . -type f -not -path '*/\.*')"
+
+    [[ $status == "0" ]]
+
+    [[ -d lib ]]
+    [[ ! -d lib/lib ]]
+    [[ -d lib/src ]]
+    [[ -f lib/src/libfile1.txt ]]
+    [[ -f lib/src/libfile2.txt ]]
+    [[ -f lib/src/srcfile1.txt ]]
+    [[ -f lib/src/srcfile2txt ]]
+    [[ -f lib/rootfile1.txt ]]
+}
+
 @test 'can include without renaming' {
     # save current dir to cd back to later
     curr_dir="$PWD"

--- a/test/splitin/end-to-end.bats
+++ b/test/splitin/end-to-end.bats
@@ -243,7 +243,7 @@ function teardown() {
     [[ -f lib/src/libfile1.txt ]]
     [[ -f lib/src/libfile2.txt ]]
     [[ -f lib/src/srcfile1.txt ]]
-    [[ -f lib/src/srcfile2txt ]]
+    [[ -f lib/src/srcfile2.txt ]]
     [[ -f lib/rootfile1.txt ]]
 }
 


### PR DESCRIPTION
closes #31 

note this probably doesnt work on windows... need to go in and make it more portable, but the core functionality is there.

it does several things:
- manually maps every single file for the user, so if they do `include_as`: `src/` - `dest/` it will iterate over src and insert every file mapped to `dest/`
- uses `git ls-tree` to get a list of files in the repo. it only iterates over a file if its in this list of files, otherwise we waste time iterating over directories we dont need
- filters duplicates

adds/changes some tests to document this new behavior.

These tests probably wont pass on windows yet, but i need to know what the errors are before I start debugging, so this will trigger a pipeline run for that