### PR TITLE
Split out as command

### DIFF
--- a/doc/gen_docs.sh
+++ b/doc/gen_docs.sh
@@ -4,6 +4,7 @@
 ./doc/gen_repo_file.sh > doc/repo_file.md
 ./doc/gen_readme.sh > doc/README.md
 ./doc/gen_split_out.sh > doc/split-out.md
+./doc/gen_split_out_as.sh > doc/split-out-as.md
 ./doc/gen_split_in.sh > doc/split-in.md
 ./doc/gen_split_in_as.sh > doc/split-in-as.md
 ./doc/gen_topbase.sh > doc/topbase.md

--- a/doc/gen_split_out_as.sh
+++ b/doc/gen_split_out_as.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+SUBCOMMAND="split-out-as" envsubst < ./doc/subcommand.template
+
+echo "\`\`\`"
+./target/release/mgt split-out-as --help
+echo "\`\`\`"

--- a/doc/readme.template
+++ b/doc/readme.template
@@ -7,6 +7,7 @@ automatically generated output of `mgt --help`
 
 
 * [split-out](./split-out.md)
+* [split-out-as](./split-out-as.md)
 * [split-in](./split-in.md)
 * [split-in-as](./split-in-as.md)
 * [topbase](./topbase.md)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,6 +1,7 @@
 use clap::{Arg, App, SubCommand, ArgMatches};
 
 use super::split_out::run_split_out;
+use super::split_out::run_split_out_as;
 use super::split_in::run_split_in;
 use super::split_in::run_split_in_as;
 use super::topbase::run_topbase;
@@ -280,7 +281,7 @@ pub fn run_command(name: &str, matches: &ArgMatches) {
         SplitIn => run_split_in(matches.subcommand_matches(name).unwrap()),
         SplitInAs => run_split_in_as(matches.subcommand_matches(name).unwrap()),
         SplitOut => run_split_out(matches.subcommand_matches(name).unwrap()),
-        SplitOutAs => (),
+        SplitOutAs => run_split_out_as(matches.subcommand_matches(name).unwrap()),
         Topbase => run_topbase(matches.subcommand_matches(name).unwrap()),
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -234,6 +234,7 @@ pub fn split_out_as<'a, 'b>() -> App<'a, 'b> {
                 .short(OUTPUT_BRANCH_ARG[1])
                 .takes_value(true)
                 .value_name(OUTPUT_BRANCH_NAME)
+                .required(true)
                 .help("name of branch that will be created with new split history")
         );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ fn get_cli_input<'a>() -> ArgMatches<'a> {
         commands::split_in(),
         commands::split_in_as(),
         commands::split_out(),
+        commands::split_out_as(),
         commands::topbase(),
     ]);
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -64,6 +64,9 @@ run_end_to_end_tests() {
     echo "GIT TOPBASE:"
     PROGRAM_PATH="$PROGRAM_PATH" bats test/topbase
     echo ""
+    echo "SPLIT-OUT-AS:"
+    PROGRAM_PATH="$PROGRAM_PATH" bats test/splitoutas
+    echo ""
 }
 
 run_all_tests() {

--- a/test/splitoutas/end-to-end.bats
+++ b/test/splitoutas/end-to-end.bats
@@ -1,0 +1,75 @@
+function make_temp_repo() {
+    cd $BATS_TMPDIR
+    mkdir -p $1
+    cd $1
+    if [[ ! -d .git ]]; then
+        git init
+        git config --local user.email "temp"
+        git config --local user.name "temp"
+        echo "name of repo: $1" > $1.txt
+        git add $1.txt
+        git commit -m "initial commit for $1"
+    fi
+}
+
+function set_seperator() {
+    # I wanna use these tests for both windows (git bash)
+    # and linux, so I need to change the separator
+    if [[ -d /c/ ]]; then
+        SEP="\\"
+    else
+        SEP="/"
+    fi
+}
+
+function setup() {
+    set_seperator
+    make_temp_repo test_remote_repo
+    test_remote_repo="test_remote_repo"
+    make_temp_repo test_remote_repo2
+    test_remote_repo2="test_remote_repo2"
+    cd $BATS_TMPDIR/test_remote_repo
+}
+
+function teardown() {
+    cd $BATS_TMPDIR
+    if [[ -d test_remote_repo ]]; then
+        rm -rf test_remote_repo
+    fi
+    if [[ -d test_remote_repo2 ]]; then
+        rm -rf test_remote_repo2
+    fi
+}
+
+@test 'requires an output branch name' {
+    mkdir -p this
+    mkdir -p this/path
+    mkdir -p this/path/exists
+    echo "file1" > this/path/exists/file1.txt
+    git add this/ && git commit -m "file1"
+
+    run $PROGRAM_PATH split-out-as --as this/path/exists
+    echo "$output"
+    [[ $status != "0" ]]
+    [[ $output == *"required arguments"* ]]
+}
+
+@test 'moves everything in --as to the root of the newly created repo' {
+    mkdir -p this
+    mkdir -p this/path
+    mkdir -p this/path/exists
+    echo "file1" > this/path/exists/file1.txt
+    git add this/ && git commit -m "file1"
+    echo "rootfile1" > rootfile1.txt
+    git add rootfile1.txt && git commit -m "rootfile1.txt"
+
+    run $PROGRAM_PATH split-out-as --as this/path/exists/ -o newbranch -v
+    echo "$output"
+    echo "$(git branch -v)"
+    echo "$(git log --oneline)"
+    [[ "$(git branch --show-current)" == "newbranch" ]]
+    [[ -f file1.txt ]]
+    [[ ! -d this/ ]]
+    [[ ! -f rootfile1.txt ]]
+    [[ $status == "0" ]]
+}


### PR DESCRIPTION
closes #29 

adds the `split-out-as` command. very basic alias for minimal `split-out` functionality.

useful when you have a simple structure and you just want to split out a single subdirectory,
and you dont want to write a repo file

