### PR TITLE
Fix files with spaces

### DIFF
--- a/test/splitin/end-to-end.bats
+++ b/test/splitin/end-to-end.bats
@@ -222,11 +222,9 @@ function teardown() {
     "
 
     echo "$repo_file_contents" > repo_file.sh
-    echo "$(git split in repo_file.sh --dry-run)"
-
     run $PROGRAM_PATH split-in repo_file.sh --verbose
-    [[ $status == "0" ]]
     echo "$output"
+    [[ $status == "0" ]]
     echo "$(find . -not -path '*/\.*')"
 
     # since we excluded lib, it shouldnt be there

--- a/test/splitin/end-to-end.bats
+++ b/test/splitin/end-to-end.bats
@@ -544,3 +544,53 @@ function teardown() {
     [[ $status == "0" ]]
     [[ $output == *"rebasing non-interactively"* ]]
 }
+
+@test 'can rename weird file and folder names' {
+    curr_dir="$PWD"
+    cd "$BATS_TMPDIR/test_remote_repo2"
+
+    echo "a" > a.txt
+    git add a.txt && git commit -m "a"
+    echo "b" > "du[mbfile.txt"
+    git add . && git commit -m "dumbfile"
+    mkdir -p "dum'lib"
+    echo "lib" > "dum'lib/lib.txt"
+    git add . && git commit -m "dumblib"
+
+    echo "$(find . -type f -not -path '*/\.*')"
+
+    [[ -f a.txt ]]
+    [[ -f "du[mbfile.txt" ]]
+    [[ -d "dum'lib/" ]]
+
+    cd "$curr_dir"
+
+    # I originally wanted to also maybe support files with \ in
+    # them, but i think it'd be too difficult due to multiple levels of
+    # escaping, and also it being treated differently on windows vs linux
+    repo_file_contents="
+    remote_repo=\"..$SEP$test_remote_repo2\"
+    include_as=(
+        \"dumbfile.txt\" \"du[mbfile.txt\"
+        \"spaghetti/\" \"dum'lib/\"
+    )
+    "
+    echo "$repo_file_contents" > repo_file.sh
+    echo "repo file contents:"
+    cat repo_file.sh
+
+    [[ ! -f "dumbfile.txt" ]]
+
+    run $PROGRAM_PATH split-in repo_file.sh --verbose
+
+    echo "$(find . -type f -not -path '*/\.*')"
+
+    echo "$output"
+    [[ $status == "0" ]]
+
+    [[ ! -f a.txt ]]
+    [[ -f "dumbfile.txt" ]]
+    [[ -d spaghetti/ ]]
+    [[ ! -d "dum'lib/" ]]
+    [[ -f "spaghetti/lib.txt" ]]
+}

--- a/test/splitout/end-to-end.bats
+++ b/test/splitout/end-to-end.bats
@@ -295,6 +295,43 @@ function teardown() {
     [[ -f new_a/a1/a1.txt ]]
 }
 
+@test 'can only include_as a single to root' {
+    repo_file_contents="
+    remote_repo=\"..$SEP$test_remote_repo2\"
+    include_as=(
+        \"a/\"
+        \" \"
+    )
+    "
+
+    echo "$repo_file_contents" > repo_file.sh
+
+    mkdir -p a
+    mkdir -p a/a1
+    mkdir -p b
+    echo "a" > a/a.txt
+    echo "a1" > a/a1/a1.txt
+    echo "ac" > a/c.txt
+    echo "b" > b/b.txt
+    git add a
+    git commit -m "a"
+    git add b
+    git commit -m "b"
+
+    run $PROGRAM_PATH split-out repo_file.sh --verbose
+
+    echo "$output"
+    [[ $status == "0" ]]
+
+    # b should not exist, and entirety of a/ should
+    # be renamed to new_a/
+    [[ ! -d a ]]
+    [[ ! -d b ]]
+    [[ -f c.txt ]]
+    [[ -f a.txt ]]
+    [[ -f a1/a1.txt ]]
+}
+
 @test 'can include_as to rename a nested folder but keep everything else' {
     repo_file_contents="
     remote_repo=\"..$SEP$test_remote_repo2\"


### PR DESCRIPTION
fixes issue where files/folders with spaces cause issues due to how the arguments are passed to the command execution.

The solution is to keep the include/exclude arguments as a vector of strings rather than one big string.

also adds some tests for certain file name situations.
