### PR TITLE
Dont split if modified files

### DIFF
--- a/src/split_in.rs
+++ b/src/split_in.rs
@@ -356,6 +356,7 @@ pub fn run_split_in(matches: &ArgMatches) {
         .verify_dependencies()
         .validate_repo_file()
         .change_to_repo_root()
+        .safe_to_proceed()
         .make_and_checkout_output_branch()
         .populate_empty_branch_with_remote_commits()
         .generate_arg_strings();
@@ -405,6 +406,7 @@ pub fn run_split_in_as(matches: &ArgMatches) {
         .verify_dependencies()
         .validate_repo_file()
         .change_to_repo_root()
+        .safe_to_proceed()
         .make_and_checkout_output_branch()
         .populate_empty_branch_with_remote_commits()
         .generate_arg_strings();

--- a/src/split_out.rs
+++ b/src/split_out.rs
@@ -240,6 +240,7 @@ pub fn run_split_out(matches: &ArgMatches) {
         .save_current_dir()
         .get_repository_from_current_dir()
         .change_to_repo_root()
+        .safe_to_proceed()
         .generate_arg_strings()
         .make_and_checkout_output_branch();
 
@@ -300,6 +301,7 @@ pub fn run_split_out_as(matches: &ArgMatches) {
         .verify_dependencies()
         .validate_repo_file()
         .change_to_repo_root()
+        .safe_to_proceed()
         .generate_arg_strings()
         .make_and_checkout_output_branch();
 

--- a/test/splitin/end-to-end.bats
+++ b/test/splitin/end-to-end.bats
@@ -98,6 +98,37 @@ function teardown() {
     [[ -f this/path/will/be/created/lib/file.txt ]]
 }
 
+@test 'should not run if user has modified files' {
+    repo_file_contents="
+    remote_repo=\"..$SEP$test_remote_repo2\"
+    include_as=(
+        \"lib/\" \" \"
+    )
+    "
+    echo "$repo_file_contents" > repo_file.sh
+
+    # create a modified file
+    echo "abc" > abc.txt && git add abc.txt && git commit -m "abc"
+    # now modify it so that it shows up to git as modified but unstaged
+    echo "abcd" > abc.txt
+
+    echo "$(git status)"
+    echo "$(find . -not -path '*/\.*')"
+
+    git_log_before="$(git log --oneline)"
+    # this should exit with a warning that you have modified files
+    # and we should not run, otherwise your changes might be lost
+    run $PROGRAM_PATH split-in repo_file.sh --verbose -o newbranch1
+    git_log_after="$(git log --oneline)"
+    echo "$output"
+    echo "$(git status)"
+    echo "$(find . -not -path '*/\.*')"
+    [[ $status == 1 ]]
+    [[ "$(git branch --show-current)" == "master" ]]
+    [[ "$git_log_before" == "$git_log_after" ]]
+    [[ $output == *"modified changes"* ]]
+}
+
 @test 'can split in to a specific output branch' {
     repo_file_contents="
     remote_repo=\"..$SEP$test_remote_repo2\"


### PR DESCRIPTION
basically adds a safety check: dont run any split commands (any split command will checkout different branches, and potentially rewrite history) if the user has modified files. We dont want to overwrite the users modified files

closes #34 