### PR TITLE
Topbase add label

### DIFF
--- a/src/split.rs
+++ b/src/split.rs
@@ -27,6 +27,7 @@ pub struct Runner<'a> {
     pub verbose: bool,
     pub should_rebase: bool,
     pub should_topbase: bool,
+    pub topbase_add_label: bool,
     pub repo_file: RepoFile,
     pub repo_root_dir: PathBuf,
     pub topbase_top_ref: Option<String>,
@@ -56,6 +57,7 @@ impl<'a> Runner<'a> {
             verbose: is_verbose,
             should_rebase: is_rebase,
             should_topbase: is_topbase,
+            topbase_add_label: false,
             repo_file: RepoFile::new(),
             topbase_top_ref: None,
             repo_original_ref: None,
@@ -73,6 +75,11 @@ impl<'a> Runner<'a> {
                 None
             }
         }
+    }
+
+    pub fn add_label_before_topbase(mut self, flag: bool) -> Self {
+        self.topbase_add_label = flag;
+        self
     }
 
     // get the current ref that this git repo is pointing to

--- a/src/split_out.rs
+++ b/src/split_out.rs
@@ -241,6 +241,7 @@ pub fn run_split_out(matches: &ArgMatches) {
         .get_repository_from_current_dir()
         .change_to_repo_root()
         .safe_to_proceed()
+        .add_label_before_topbase(true)
         .generate_arg_strings()
         .make_and_checkout_output_branch();
 

--- a/src/topbase.rs
+++ b/src/topbase.rs
@@ -167,6 +167,14 @@ impl<'a> Topbase for Runner<'a> {
             }
         }
 
+        // if we've made it this far, that
+        // means we have commits to topbase
+        // so we should add a label here of the upstream
+        // branch, so if the user does a git log after topbase
+        // they can visualize which commits were added on top
+        let label_name = format!("{}-remote", current_branch);
+        let _ = exec_helpers::execute(&["git", "branch", label_name.as_str(), upstream_branch.as_str()]);
+
         // rebase_data="pick <hash> <msg>
         // pick <hash> <msg>
         // pick <hash> <msg>

--- a/src/topbase.rs
+++ b/src/topbase.rs
@@ -167,13 +167,18 @@ impl<'a> Topbase for Runner<'a> {
             }
         }
 
-        // if we've made it this far, that
-        // means we have commits to topbase
-        // so we should add a label here of the upstream
-        // branch, so if the user does a git log after topbase
-        // they can visualize which commits were added on top
-        let label_name = format!("{}-remote", current_branch);
-        let _ = exec_helpers::execute(&["git", "branch", label_name.as_str(), upstream_branch.as_str()]);
+        // only add label in certain circumstances,
+        // otherwise a label being added is unnecessary
+        // and annoying
+        if self.topbase_add_label {
+            // if we've made it this far, that
+            // means we have commits to topbase
+            // so we should add a label here of the upstream
+            // branch, so if the user does a git log after topbase
+            // they can visualize which commits were added on top
+            let label_name = format!("{}-remote", current_branch);
+            let _ = exec_helpers::execute(&["git", "branch", label_name.as_str(), upstream_branch.as_str()]);
+        }
 
         // rebase_data="pick <hash> <msg>
         // pick <hash> <msg>


### PR DESCRIPTION
closes #47 

adds feature to topbase to add a label to the base branch before topbasing. this is only for split-out mode. This is convenient because when doing a `split-out --topbase` you can then see a label of where the old branch was so you can visually compare what was topbased. This is not necessary for regular topbase usage, or for `split-in --topbase` because in both of those modes, the branch labels already exist