### PR TITLE
updates gumdrop dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 toml =  { version = "0.5.7", features = ["preserve_order"] }
 git-url-parse = "0.3.0"
 die = { path="die" }
-gumdrop = { git = "https://github.com/nikita-skobov/gumdrop", rev = "f29c1f9839329cf5998257e097fc18930255627e" }
+gumdrop = { git = "https://github.com/nikita-skobov/gumdrop", rev = "7ee4940bd8e6e41d207aa8bf82ba2a80aa82c1c0" }
 
 [features]
 gittests = []


### PR DESCRIPTION
fixes an error I made when implementing the new help output feature in my gumdrop fork